### PR TITLE
update ConsolePlugin to v1 version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -104,14 +104,16 @@ spec:
   type: ClusterIP
   sessionAffinity: None
 ---
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: console-customization
 spec:
   displayName: 'OpenShift Console Customization Plugin'
-  service:
-    name: console-customization-plugin
-    namespace: console-customization-plugin
-    port: 9443
-    basePath: '/'
+  backend:
+    service:
+      name: console-customization-plugin
+      namespace: console-customization-plugin
+      port: 9443
+      basePath: '/'
+    type: Service


### PR DESCRIPTION
`v1alpha1` version of ConsolePlugin will be removed in 4.18 so updating ConsolePlugin manifest, in this way we will have correct and expected YAML when creating `console-customization` plugin from `manifest.yaml` file

@spadgett Could you help review? Thanks a lot!